### PR TITLE
add `$template_tags` to `Email_Encoder_Settings` class

### DIFF
--- a/core/includes/classes/class-email-encoder-bundle-settings.php
+++ b/core/includes/classes/class-email-encoder-bundle-settings.php
@@ -52,6 +52,14 @@ class Email_Encoder_Settings{
 	 */
 	private $widget_callback_hook;
 
+        /**
+	 * The template tags
+	 *
+	 * @var string
+	 * @since x.x.x
+	 */
+	private $template_tags;
+
 	/**
 	 * The settings key
 	 *


### PR DESCRIPTION
add property `$template_tags` to `Email_Encoder_Settings` class in `class-email-encoder-bundle-settings.php` to remove deprecation warnings in PHP v8.3

@jannis24 needs a little attention for version number/doc comments. 